### PR TITLE
Add coverage.py to requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ $ source activate kernel
 $ python -m pytest -vvv
 ```
 
+To see the code coverage of the test suite, run the following commands.
+```bash
+$ coverage run -m pytest -vvv
+$ coverge report
+```
+
 ## Citing this work
 
 Please quote the following citation when referring to this work.

--- a/environment.yml
+++ b/environment.yml
@@ -16,3 +16,4 @@ dependencies:
     - astropy==2.0.11
     - twine==1.12.1
     - pytest==4.1.1
+    - coverage==4.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 astropy==2.0.11
+coverage=4.5.2
 emcee==2.2.1
 matplotlib==2.0.0
 numpy==1.11.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 astropy==2.0.11
-coverage=4.5.2
+coverage==4.5.2
 emcee==2.2.1
 matplotlib==2.0.0
 numpy==1.11.2

--- a/test_file.txt
+++ b/test_file.txt
@@ -1,1 +1,0 @@
-This is a Travis test file.


### PR DESCRIPTION
Includes `coverage.py` to requirements packages and instructions added to the README to report the code coverage of the test suite